### PR TITLE
[refactor] SampleVO / SampleDefaultVO에 Lombok @Getter/@Setter 적용

### DIFF
--- a/src/main/java/egovframework/example/sample/service/SampleDefaultVO.java
+++ b/src/main/java/egovframework/example/sample/service/SampleDefaultVO.java
@@ -19,6 +19,9 @@ import java.io.Serializable;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * @Class Name : SampleDefaultVO.java
  * @Description : SampleDefaultVO Class
@@ -35,6 +38,8 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *
  *  Copyright (C) by MOPAS All right reserved.
  */
+@Getter
+@Setter
 public class SampleDefaultVO implements Serializable {
 
 	/**
@@ -68,78 +73,6 @@ public class SampleDefaultVO implements Serializable {
 
 	/** recordCountPerPage */
 	private int recordCountPerPage = 10;
-
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	public String getSearchUseYn() {
-		return searchUseYn;
-	}
-
-	public void setSearchUseYn(String searchUseYn) {
-		this.searchUseYn = searchUseYn;
-	}
-
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
 
 	@Override
 	public String toString() {

--- a/src/main/java/egovframework/example/sample/service/SampleVO.java
+++ b/src/main/java/egovframework/example/sample/service/SampleVO.java
@@ -17,6 +17,9 @@ package egovframework.example.sample.service;
 
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * @Class Name : SampleVO.java
  * @Description : SampleVO Class
@@ -33,6 +36,8 @@ import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
  *
  *  Copyright (C) by MOPAS All right reserved.
  */
+@Getter
+@Setter
 public class SampleVO extends SampleDefaultVO {
 
 	private static final long serialVersionUID = 1L;
@@ -54,45 +59,5 @@ public class SampleVO extends SampleDefaultVO {
 	/** 등록자 */
 	@EgovNullCheck(message="{confirm.required.user}")
 	private String regUser;
-
-	public String getId() {
-		return id;
-	}
-
-	public void setId(String id) {
-		this.id = id;
-	}
-
-	public String getName() {
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	public String getDescription() {
-		return description;
-	}
-
-	public void setDescription(String description) {
-		this.description = description;
-	}
-
-	public String getUseYn() {
-		return useYn;
-	}
-
-	public void setUseYn(String useYn) {
-		this.useYn = useYn;
-	}
-
-	public String getRegUser() {
-		return regUser;
-	}
-
-	public void setRegUser(String regUser) {
-		this.regUser = regUser;
-	}
 
 }


### PR DESCRIPTION
## 변경 사유
`pom.xml`에 Lombok 의존성이 이미 `<scope>provided</scope>`로 등록되어 있는데도 `SampleVO`와 `SampleDefaultVO`는 수작업 getter/setter 그대로 유지하고 있습니다. 두 클래스를 `@Getter`/`@Setter`로 정리해 필드를 단일 진실원천으로 만듭니다.

## 변경 내용
- `SampleVO` — 수동 접근자 10개 제거, `@Getter`/`@Setter` 추가
- `SampleDefaultVO` — 수동 접근자 18개 제거, `@Getter`/`@Setter` 추가. `toString()`은 `ToStringBuilder.reflectionToString` 기반으로 모든 필드를 반사 출력하는 의도가 있으므로 그대로 유지 (Lombok `@ToString`은 선언 필드만 다뤄 의미가 다름)

## 영향 범위
- 컴파일 후 public method 시그니처(`getId`, `setName`, …)는 기존과 동일 — 호출부/JSP EL/MyBatis 매퍼는 변경 불필요
- `@EgovNullCheck` 필드 어노테이션 영향 없음
- 직렬화 호환을 위해 `serialVersionUID` 그대로 유지

## 체크리스트
- [x] 단일 주제(Lombok 도입)
- [x] 5.0.x 브랜치 대상
- [x] 외부 method 시그니처 미변경
- [x] 검증/직렬화/매핑 어노테이션 보존