### PR TITLE
[refactor] SampleMapper 정적 SQL을 MyBatis 어노테이션 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/example/sample/service/impl/SampleMapper.java
+++ b/src/main/java/egovframework/example/sample/service/impl/SampleMapper.java
@@ -17,6 +17,12 @@ package egovframework.example.sample.service.impl;
 
 import java.util.List;
 
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Results;
+import org.apache.ibatis.annotations.Result;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
 import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 import egovframework.example.sample.service.SampleVO;
@@ -33,6 +39,7 @@ import egovframework.example.sample.service.SampleVO;
  *          수정일          수정자           수정내용
  *  ----------------    ------------    ---------------------------
  *   2014.01.24        표준프레임워크센터          최초 생성
+ *   2025.05.20        표준프레임워크센터          정적 SQL 어노테이션 방식으로 전환
  *
  * </pre>
  */
@@ -45,6 +52,7 @@ public interface SampleMapper {
 	 * @return 등록 결과
 	 * @exception Exception
 	 */
+	@Insert("INSERT INTO SAMPLE (ID, NAME, DESCRIPTION, USE_YN, REG_USER) VALUES (#{id}, #{name}, #{description}, #{useYn}, #{regUser})")
 	void insertSample(SampleVO vo) throws Exception;
 
 	/**
@@ -53,6 +61,7 @@ public interface SampleMapper {
 	 * @return void형
 	 * @exception Exception
 	 */
+	@Update("UPDATE SAMPLE SET NAME=#{name}, DESCRIPTION=#{description}, USE_YN=#{useYn} WHERE ID=#{id}")
 	void updateSample(SampleVO vo) throws Exception;
 
 	/**
@@ -61,6 +70,7 @@ public interface SampleMapper {
 	 * @return void형
 	 * @exception Exception
 	 */
+	@Delete("DELETE FROM SAMPLE WHERE ID=#{id}")
 	void deleteSample(SampleVO vo) throws Exception;
 
 	/**
@@ -69,10 +79,18 @@ public interface SampleMapper {
 	 * @return 조회한 글
 	 * @exception Exception
 	 */
+	@Select("SELECT ID, NAME, DESCRIPTION, USE_YN, REG_USER FROM SAMPLE WHERE ID=#{id}")
+	@Results(id = "sampleResult", value = {
+		@Result(property = "id",          column = "id"),
+		@Result(property = "name",        column = "name"),
+		@Result(property = "description", column = "description"),
+		@Result(property = "useYn",       column = "use_yn"),
+		@Result(property = "regUser",     column = "reg_user")
+	})
 	SampleVO selectSample(SampleVO vo) throws Exception;
 
 	/**
-	 * 글 목록을 조회한다.
+	 * 글 목록을 조회한다. (동적 SQL — XML 매퍼 사용)
 	 * @param vo - 조회할 정보가 담긴 VO
 	 * @return 글 목록
 	 * @exception Exception
@@ -80,7 +98,7 @@ public interface SampleMapper {
 	List<?> selectSampleList(SampleVO vo) throws Exception;
 
 	/**
-	 * 글 총 갯수를 조회한다.
+	 * 글 총 갯수를 조회한다. (동적 SQL — XML 매퍼 사용)
 	 * @param vo - 조회할 정보가 담긴 VO
 	 * @return 글 총 갯수
 	 * @exception

--- a/src/main/resources/egovframework/sqlmap/example/mappers/EgovSample_Sample_SQL.xml
+++ b/src/main/resources/egovframework/sqlmap/example/mappers/EgovSample_Sample_SQL.xml
@@ -2,56 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="egovframework.example.sample.service.impl.SampleMapper">
 
-	<resultMap id="sample" type="egovframework.example.sample.service.SampleVO">
-		<result property="id" column="id"/>
-		<result property="name" column="name"/>
-		<result property="description" column="description"/>
-		<result property="useYn" column="use_yn"/>
-		<result property="regUser" column="reg_user"/>
-	</resultMap>
-
-	<insert id="insertSample" parameterType="SampleVO">
-
-			INSERT INTO SAMPLE
-				( ID
-				  , NAME
-				  , DESCRIPTION
-				  , USE_YN
-				  , REG_USER )
-			VALUES ( #{id}
-				  , #{name}
-				  , #{description}
-				  , #{useYn}
-				  , #{regUser} )
-
-	</insert>
-
-	<update id="updateSample">
-
-			UPDATE SAMPLE
-			SET ID=#{id}
-				, NAME=#{name}
-				, DESCRIPTION=#{description}
-				, USE_YN=#{useYn}
-				  WHERE ID=#{id}
-
-	</update>
-
-	<delete id="deleteSample">
-
-			DELETE FROM SAMPLE
-			WHERE ID=#{id}
-
-	</delete>
-
-	<select id="selectSample" resultMap="sample">
-
-			SELECT
-				ID, NAME, DESCRIPTION, USE_YN, REG_USER
-			FROM SAMPLE
-			WHERE ID=#{id}
-
-	</select>
+	<!-- insertSample, updateSample, deleteSample, selectSample 는 SampleMapper.java 어노테이션으로 정의 -->
 
 	<select id="selectSampleList" parameterType="searchVO" resultType="egovMap">
 


### PR DESCRIPTION
## 변경 사유
eGovFrame 5.0에 신규 반영된 MyBatis 어노테이션 방식을 적극 활용. `SampleMapper`의 정적 SQL을 어노테이션으로 전환해 XML 의존을 줄이고 IDE에서 타입 안전성/리팩토링 지원을 확보.

## 변경 내용
- `src/main/java/egovframework/example/sample/service/impl/SampleMapper.java`
  - `@Insert` / `@Update` / `@Delete` / `@Select` + `@Results` 어노테이션 추가
  - 메서드 시그니처 변경 없음
- `src/main/resources/egovframework/sqlmap/example/mappers/EgovSample_Sample_SQL.xml`
  - 정적 쿼리 4개 제거: `insertSample`, `updateSample`, `deleteSample`, `selectSample`
  - 동적 쿼리 2개 유지: `selectSampleList`, `selectSampleListTotCnt` (조건 분기 복잡도로 어노테이션 단일화 시 가독성 저하)

## 영향 범위
- 호출부(Service/Controller/테스트) 코드 변경 없음
- SQL 의미 동일, parameterType/resultMap은 어노테이션 자동 매핑으로 대체
- `mvn -B -ntp -DskipTests compile`로 빌드 성공 확인

## 체크리스트
- [x] 단일 주제 (정적 쿼리 4개의 어노테이션 전환)
- [x] 5.0.x 브랜치 대상
- [x] 메서드 시그니처 유지
- [x] 동적 SQL은 후속 PR로 분리 (atomic 원칙)