### PR TITLE
[test][web-sample] EgovSampleServiceImpl 단위 테스트 추가

### DIFF
--- a/src/test/java/egovframework/example/sample/service/impl/EgovSampleServiceImplTestDeleteSampleTest.java
+++ b/src/test/java/egovframework/example/sample/service/impl/EgovSampleServiceImplTestDeleteSampleTest.java
@@ -1,0 +1,80 @@
+package egovframework.example.sample.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.test.context.ContextConfiguration;
+
+import egovframework.example.sample.service.EgovSampleService;
+import egovframework.example.sample.service.SampleVO;
+import egovframework.test.EgovTestAbstractSpring;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * [게시판][EgovSampleServiceImpl.deleteSample] ServiceImpl 단위 테스트
+ *
+ * @author 이백행
+ * @since 2024-09-21
+ *
+ */
+
+@ContextConfiguration(classes = { EgovSampleServiceImplTestDeleteSampleTest.class, EgovTestAbstractSpring.class })
+
+@Configuration
+
+@ImportResource({ "classpath*:egovframework/spring/context-idgen.xml", })
+
+@ComponentScan(useDefaultFilters = false, basePackages = {
+		"egovframework.example.sample.service.impl", }, includeFilters = {
+				@Filter(type = FilterType.ASSIGNABLE_TYPE, classes = { EgovSampleServiceImpl.class,
+						SampleMapper.class, }) })
+
+@RequiredArgsConstructor
+@Slf4j
+class EgovSampleServiceImplTestDeleteSampleTest extends EgovTestAbstractSpring {
+
+	/**
+	 *
+	 */
+	@Autowired
+	private EgovSampleService egovSampleService;
+
+	@Test
+	void test() throws Exception {
+		// given
+		final SampleVO sampleVO = new SampleVO();
+
+		sampleVO.setName("test 등록명");
+		sampleVO.setUseYn("Y");
+		sampleVO.setDescription("test 등록 설명");
+		sampleVO.setRegUser("test");
+
+		egovSampleService.insertSample(sampleVO);
+
+		final String id = sampleVO.getId();
+
+		if (log.isDebugEnabled()) {
+			log.debug("id={}", id);
+		}
+
+		// when
+		final SampleVO deleteVO = new SampleVO();
+		deleteVO.setId(id);
+
+		egovSampleService.deleteSample(deleteVO);
+
+		// then
+		final SampleVO selectVO = new SampleVO();
+		selectVO.setId(id);
+
+		assertThrows(Exception.class, () -> egovSampleService.selectSample(selectVO), "글을 삭제한다.");
+	}
+
+}

--- a/src/test/java/egovframework/example/sample/service/impl/EgovSampleServiceImplTestSelectSampleListTest.java
+++ b/src/test/java/egovframework/example/sample/service/impl/EgovSampleServiceImplTestSelectSampleListTest.java
@@ -1,0 +1,88 @@
+package egovframework.example.sample.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.test.context.ContextConfiguration;
+
+import egovframework.example.sample.service.EgovSampleService;
+import egovframework.example.sample.service.SampleVO;
+import egovframework.test.EgovTestAbstractSpring;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * [게시판][EgovSampleServiceImpl.selectSampleList] ServiceImpl 단위 테스트
+ *
+ * @author 이백행
+ * @since 2024-09-21
+ *
+ */
+
+@ContextConfiguration(classes = { EgovSampleServiceImplTestSelectSampleListTest.class, EgovTestAbstractSpring.class })
+
+@Configuration
+
+@ImportResource({ "classpath*:egovframework/spring/context-idgen.xml", })
+
+@ComponentScan(useDefaultFilters = false, basePackages = {
+		"egovframework.example.sample.service.impl", }, includeFilters = {
+				@Filter(type = FilterType.ASSIGNABLE_TYPE, classes = { EgovSampleServiceImpl.class,
+						SampleMapper.class, }) })
+
+@RequiredArgsConstructor
+@Slf4j
+class EgovSampleServiceImplTestSelectSampleListTest extends EgovTestAbstractSpring {
+
+	/**
+	 *
+	 */
+	@Autowired
+	private EgovSampleService egovSampleService;
+
+	@Test
+	void test() throws Exception {
+		// given
+		final SampleVO sampleVO1 = new SampleVO();
+		sampleVO1.setName("test 목록조회1");
+		sampleVO1.setUseYn("Y");
+		sampleVO1.setDescription("test 목록조회 설명1");
+		sampleVO1.setRegUser("test");
+		egovSampleService.insertSample(sampleVO1);
+
+		final SampleVO sampleVO2 = new SampleVO();
+		sampleVO2.setName("test 목록조회2");
+		sampleVO2.setUseYn("Y");
+		sampleVO2.setDescription("test 목록조회 설명2");
+		sampleVO2.setRegUser("test");
+		egovSampleService.insertSample(sampleVO2);
+
+		// when
+		final SampleVO searchVO = new SampleVO();
+		searchVO.setFirstIndex(0);
+		searchVO.setRecordCountPerPage(10);
+
+		final List<?> resultList = egovSampleService.selectSampleList(searchVO);
+		final int totCnt = egovSampleService.selectSampleListTotCnt(searchVO);
+
+		// then
+		if (log.isDebugEnabled()) {
+			log.debug("resultList.size={}", resultList.size());
+			log.debug("totCnt={}", totCnt);
+		}
+
+		assertNotNull(resultList, "목록 결과가 null이 아니어야 한다.");
+		assertTrue(resultList.size() >= 2, "등록한 건수 이상이어야 한다.");
+		assertTrue(totCnt >= 2, "전체 건수가 등록한 건수 이상이어야 한다.");
+	}
+
+}

--- a/src/test/java/egovframework/example/sample/service/impl/EgovSampleServiceImplTestUpdateSampleTest.java
+++ b/src/test/java/egovframework/example/sample/service/impl/EgovSampleServiceImplTestUpdateSampleTest.java
@@ -1,0 +1,89 @@
+package egovframework.example.sample.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.test.context.ContextConfiguration;
+
+import egovframework.example.sample.service.EgovSampleService;
+import egovframework.example.sample.service.SampleVO;
+import egovframework.test.EgovTestAbstractSpring;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * [게시판][EgovSampleServiceImpl.updateSample] ServiceImpl 단위 테스트
+ *
+ * @author 이백행
+ * @since 2024-09-21
+ *
+ */
+
+@ContextConfiguration(classes = { EgovSampleServiceImplTestUpdateSampleTest.class, EgovTestAbstractSpring.class })
+
+@Configuration
+
+@ImportResource({ "classpath*:egovframework/spring/context-idgen.xml", })
+
+@ComponentScan(useDefaultFilters = false, basePackages = {
+		"egovframework.example.sample.service.impl", }, includeFilters = {
+				@Filter(type = FilterType.ASSIGNABLE_TYPE, classes = { EgovSampleServiceImpl.class,
+						SampleMapper.class, }) })
+
+@RequiredArgsConstructor
+@Slf4j
+class EgovSampleServiceImplTestUpdateSampleTest extends EgovTestAbstractSpring {
+
+	/**
+	 *
+	 */
+	@Autowired
+	private EgovSampleService egovSampleService;
+
+	@Test
+	void test() throws Exception {
+		// given
+		final SampleVO sampleVO = new SampleVO();
+
+		sampleVO.setName("test 등록명");
+		sampleVO.setUseYn("Y");
+		sampleVO.setDescription("test 등록 설명");
+		sampleVO.setRegUser("test");
+
+		egovSampleService.insertSample(sampleVO);
+
+		final String id = sampleVO.getId();
+
+		// when
+		final SampleVO updateVO = new SampleVO();
+		updateVO.setId(id);
+		updateVO.setName("test 수정명");
+		updateVO.setUseYn("N");
+		updateVO.setDescription("test 수정 설명");
+		updateVO.setRegUser("test");
+
+		egovSampleService.updateSample(updateVO);
+
+		// then
+		final SampleVO resultVO = new SampleVO();
+		resultVO.setId(id);
+
+		final SampleVO resultSampleVO = egovSampleService.selectSample(resultVO);
+
+		if (log.isDebugEnabled()) {
+			log.debug("id={}", id);
+			log.debug("resultSampleVO={}", resultSampleVO);
+			log.debug("getName={}", resultSampleVO.getName());
+		}
+
+		assertEquals("test 수정명", resultSampleVO.getName(), "글을 수정한다.");
+		assertEquals("N", resultSampleVO.getUseYn(), "사용여부를 수정한다.");
+	}
+
+}


### PR DESCRIPTION
## 변경 사유

기존 `insertSample` 테스트만 존재하며, `updateSample`, `deleteSample`, `selectSampleList`, `selectSampleListTotCnt` 메서드에 대한 테스트가 없었다. 서비스 계층의 주요 CRUD 동작을 검증하는 테스트를 추가한다.

## 변경 내용

- `EgovSampleServiceImplTestUpdateSampleTest`: 글 수정 후 변경 값 검증
- `EgovSampleServiceImplTestDeleteSampleTest`: 글 삭제 후 조회 시 예외 발생 검증
- `EgovSampleServiceImplTestSelectSampleListTest`: 목록 조회 및 전체 건수 검증

기존 테스트와 동일한 패턴 적용: `@ContextConfiguration`, `@Transactional`, HSQL 임베디드 DB, JUnit 5 (Jupiter).

## 테스트 방법 / 영향 범위

- JUnit 5 (junit-jupiter-api), Spring 통합 테스트
- HSQL 임베디드 DB 사용 (외부 DB 불필요)
- `@Transactional` 적용으로 각 테스트 후 롤백, DB 상태에 영향 없음
- 기존 운영 코드 변경 없음

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음
- [x] JUnit 5 (Jupiter) 사용
- [x] 의존성 추가 없음 (기존 junit-jupiter-api, spring-test 활용)
