### PR TITLE
[fix/test][web-sample] Lombok annotationProcessorPaths 수정 및 SampleMapper CRUD 단위 테스트 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,10 @@
 		</repository>
 	</repositories>
 
+	<properties>
+		<skipTests>true</skipTests>
+	</properties>
+
 	<dependencies>
 		<!-- 표준프레임워크 실행환경 -->
 		<dependency>
@@ -160,6 +164,13 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<release>${java.version}</release>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>${lombok.version}</version>
+						</path>
+					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -179,7 +190,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
-					<skipTests>true</skipTests>
+					<skipTests>${skipTests}</skipTests>
 					<reportFormat>xml</reportFormat>
 					<excludes>
 						<exclude>**/Abstract*.java</exclude>

--- a/src/test/java/egovframework/example/sample/service/impl/SampleMapperTestDeleteSampleTest.java
+++ b/src/test/java/egovframework/example/sample/service/impl/SampleMapperTestDeleteSampleTest.java
@@ -1,0 +1,87 @@
+package egovframework.example.sample.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.test.context.ContextConfiguration;
+
+import egovframework.example.sample.service.SampleVO;
+import egovframework.test.EgovTestAbstractSpring;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * [게시판][SampleMapper.deleteSample] DAO 단위 테스트
+ *
+ * @author 이백행
+ * @since 2024-09-21
+ *
+ */
+
+@ContextConfiguration(classes = { SampleMapperTestDeleteSampleTest.class, EgovTestAbstractSpring.class })
+
+@Configuration
+
+@ImportResource({ "classpath*:egovframework/spring/context-idgen.xml", })
+
+@ComponentScan(useDefaultFilters = false, basePackages = {
+		"egovframework.example.sample.service.impl", }, includeFilters = {
+				@Filter(type = FilterType.ASSIGNABLE_TYPE, classes = { SampleMapper.class, }) })
+
+@RequiredArgsConstructor
+@Slf4j
+class SampleMapperTestDeleteSampleTest extends EgovTestAbstractSpring {
+
+	/**
+	 * sample에 관한 데이터처리 매퍼 클래스
+	 */
+	@Autowired
+	private SampleMapper sampleMapper;
+
+	/**
+	 *
+	 */
+	@Autowired
+	private EgovIdGnrService egovIdGnrService;
+
+	@Test
+	void test() throws Exception {
+		// given
+		final SampleVO sampleVO = new SampleVO();
+
+		sampleVO.setId(egovIdGnrService.getNextStringId());
+		sampleVO.setName("test 이백행 삭제 카테고리명");
+		sampleVO.setUseYn("Y");
+		sampleVO.setDescription("test 이백행 삭제 설명");
+		sampleVO.setRegUser("test");
+
+		sampleMapper.insertSample(sampleVO);
+
+		// when
+		final SampleVO deleteVO = new SampleVO();
+		deleteVO.setId(sampleVO.getId());
+
+		sampleMapper.deleteSample(deleteVO);
+
+		// then
+		final SampleVO queryVO = new SampleVO();
+		queryVO.setId(sampleVO.getId());
+
+		final SampleVO resultSampleVO = sampleMapper.selectSample(queryVO);
+
+		if (log.isDebugEnabled()) {
+			log.debug("sampleVO.getId={}", sampleVO.getId());
+			log.debug("resultSampleVO={}", resultSampleVO);
+		}
+
+		assertNull(resultSampleVO, "글을 삭제한다.");
+	}
+
+}

--- a/src/test/java/egovframework/example/sample/service/impl/SampleMapperTestSelectSampleListTest.java
+++ b/src/test/java/egovframework/example/sample/service/impl/SampleMapperTestSelectSampleListTest.java
@@ -1,0 +1,95 @@
+package egovframework.example.sample.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.test.context.ContextConfiguration;
+
+import egovframework.example.sample.service.SampleVO;
+import egovframework.test.EgovTestAbstractSpring;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * [게시판][SampleMapper.selectSampleList / selectSampleListTotCnt] DAO 단위 테스트
+ *
+ * @author 이백행
+ * @since 2024-09-21
+ *
+ */
+
+@ContextConfiguration(classes = { SampleMapperTestSelectSampleListTest.class, EgovTestAbstractSpring.class })
+
+@Configuration
+
+@ImportResource({ "classpath*:egovframework/spring/context-idgen.xml", })
+
+@ComponentScan(useDefaultFilters = false, basePackages = {
+		"egovframework.example.sample.service.impl", }, includeFilters = {
+				@Filter(type = FilterType.ASSIGNABLE_TYPE, classes = { SampleMapper.class, }) })
+
+@RequiredArgsConstructor
+@Slf4j
+class SampleMapperTestSelectSampleListTest extends EgovTestAbstractSpring {
+
+	/**
+	 * sample에 관한 데이터처리 매퍼 클래스
+	 */
+	@Autowired
+	private SampleMapper sampleMapper;
+
+	/**
+	 *
+	 */
+	@Autowired
+	private EgovIdGnrService egovIdGnrService;
+
+	@Test
+	void test() throws Exception {
+		// given
+		final SampleVO sampleVO1 = new SampleVO();
+		sampleVO1.setId(egovIdGnrService.getNextStringId());
+		sampleVO1.setName("test 이백행 목록조회1");
+		sampleVO1.setUseYn("Y");
+		sampleVO1.setDescription("test 이백행 목록조회 설명1");
+		sampleVO1.setRegUser("test");
+		sampleMapper.insertSample(sampleVO1);
+
+		final SampleVO sampleVO2 = new SampleVO();
+		sampleVO2.setId(egovIdGnrService.getNextStringId());
+		sampleVO2.setName("test 이백행 목록조회2");
+		sampleVO2.setUseYn("Y");
+		sampleVO2.setDescription("test 이백행 목록조회 설명2");
+		sampleVO2.setRegUser("test");
+		sampleMapper.insertSample(sampleVO2);
+
+		// when
+		final SampleVO searchVO = new SampleVO();
+		searchVO.setFirstIndex(0);
+		searchVO.setRecordCountPerPage(10);
+
+		final List<?> resultList = sampleMapper.selectSampleList(searchVO);
+		final int totCnt = sampleMapper.selectSampleListTotCnt(searchVO);
+
+		// then
+		if (log.isDebugEnabled()) {
+			log.debug("resultList.size={}", resultList.size());
+			log.debug("totCnt={}", totCnt);
+		}
+
+		assertNotNull(resultList, "목록 결과가 null이 아니어야 한다.");
+		assertTrue(resultList.size() >= 2, "등록한 건수 이상이어야 한다.");
+		assertTrue(totCnt >= 2, "전체 건수가 등록한 건수 이상이어야 한다.");
+	}
+
+}

--- a/src/test/java/egovframework/example/sample/service/impl/SampleMapperTestSelectSampleTest.java
+++ b/src/test/java/egovframework/example/sample/service/impl/SampleMapperTestSelectSampleTest.java
@@ -1,0 +1,85 @@
+package egovframework.example.sample.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.test.context.ContextConfiguration;
+
+import egovframework.example.sample.service.SampleVO;
+import egovframework.test.EgovTestAbstractSpring;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * [게시판][SampleMapper.selectSample] DAO 단위 테스트
+ *
+ * @author 이백행
+ * @since 2024-09-21
+ *
+ */
+
+@ContextConfiguration(classes = { SampleMapperTestSelectSampleTest.class, EgovTestAbstractSpring.class })
+
+@Configuration
+
+@ImportResource({ "classpath*:egovframework/spring/context-idgen.xml", })
+
+@ComponentScan(useDefaultFilters = false, basePackages = {
+		"egovframework.example.sample.service.impl", }, includeFilters = {
+				@Filter(type = FilterType.ASSIGNABLE_TYPE, classes = { SampleMapper.class, }) })
+
+@RequiredArgsConstructor
+@Slf4j
+class SampleMapperTestSelectSampleTest extends EgovTestAbstractSpring {
+
+	/**
+	 * sample에 관한 데이터처리 매퍼 클래스
+	 */
+	@Autowired
+	private SampleMapper sampleMapper;
+
+	/**
+	 *
+	 */
+	@Autowired
+	private EgovIdGnrService egovIdGnrService;
+
+	@Test
+	void test() throws Exception {
+		// given
+		final SampleVO sampleVO = new SampleVO();
+
+		sampleVO.setId(egovIdGnrService.getNextStringId());
+		sampleVO.setName("test 이백행 조회 카테고리명");
+		sampleVO.setUseYn("Y");
+		sampleVO.setDescription("test 이백행 조회 설명");
+		sampleVO.setRegUser("test");
+
+		sampleMapper.insertSample(sampleVO);
+
+		// when
+		final SampleVO queryVO = new SampleVO();
+		queryVO.setId(sampleVO.getId());
+
+		final SampleVO resultSampleVO = sampleMapper.selectSample(queryVO);
+
+		// then
+		if (log.isDebugEnabled()) {
+			log.debug("sampleVO.getId={}", sampleVO.getId());
+			log.debug("resultSampleVO={}", resultSampleVO);
+		}
+
+		assertNotNull(resultSampleVO, "조회 결과가 null이 아니어야 한다.");
+		assertEquals(sampleVO.getId(), resultSampleVO.getId(), "글을 조회한다.");
+		assertEquals(sampleVO.getName(), resultSampleVO.getName(), "이름이 일치해야 한다.");
+	}
+
+}

--- a/src/test/java/egovframework/example/sample/service/impl/SampleMapperTestUpdateSampleTest.java
+++ b/src/test/java/egovframework/example/sample/service/impl/SampleMapperTestUpdateSampleTest.java
@@ -1,0 +1,95 @@
+package egovframework.example.sample.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.test.context.ContextConfiguration;
+
+import egovframework.example.sample.service.SampleVO;
+import egovframework.test.EgovTestAbstractSpring;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * [게시판][SampleMapper.updateSample] DAO 단위 테스트
+ *
+ * @author 이백행
+ * @since 2024-09-21
+ *
+ */
+
+@ContextConfiguration(classes = { SampleMapperTestUpdateSampleTest.class, EgovTestAbstractSpring.class })
+
+@Configuration
+
+@ImportResource({ "classpath*:egovframework/spring/context-idgen.xml", })
+
+@ComponentScan(useDefaultFilters = false, basePackages = {
+		"egovframework.example.sample.service.impl", }, includeFilters = {
+				@Filter(type = FilterType.ASSIGNABLE_TYPE, classes = { SampleMapper.class, }) })
+
+@RequiredArgsConstructor
+@Slf4j
+class SampleMapperTestUpdateSampleTest extends EgovTestAbstractSpring {
+
+	/**
+	 * sample에 관한 데이터처리 매퍼 클래스
+	 */
+	@Autowired
+	private SampleMapper sampleMapper;
+
+	/**
+	 *
+	 */
+	@Autowired
+	private EgovIdGnrService egovIdGnrService;
+
+	@Test
+	void test() throws Exception {
+		// given
+		final SampleVO sampleVO = new SampleVO();
+
+		sampleVO.setId(egovIdGnrService.getNextStringId());
+		sampleVO.setName("test 이백행 등록명");
+		sampleVO.setUseYn("Y");
+		sampleVO.setDescription("test 이백행 등록 설명");
+		sampleVO.setRegUser("test");
+
+		sampleMapper.insertSample(sampleVO);
+
+		final String id = sampleVO.getId();
+
+		// when
+		final SampleVO updateVO = new SampleVO();
+		updateVO.setId(id);
+		updateVO.setName("test 이백행 수정명");
+		updateVO.setUseYn("N");
+		updateVO.setDescription("test 이백행 수정 설명");
+		updateVO.setRegUser("test");
+
+		sampleMapper.updateSample(updateVO);
+
+		// then
+		final SampleVO queryVO = new SampleVO();
+		queryVO.setId(id);
+
+		final SampleVO resultSampleVO = sampleMapper.selectSample(queryVO);
+
+		if (log.isDebugEnabled()) {
+			log.debug("id={}", id);
+			log.debug("resultSampleVO={}", resultSampleVO);
+			log.debug("getName={}", resultSampleVO.getName());
+		}
+
+		assertEquals("test 이백행 수정명", resultSampleVO.getName(), "글을 수정한다.");
+		assertEquals("N", resultSampleVO.getUseYn(), "사용여부를 수정한다.");
+	}
+
+}


### PR DESCRIPTION
Lombok `@Getter`/`@Setter` 도입(#26) 이후 `maven-compiler-plugin`에 `annotationProcessorPaths` 설정이 누락되어 로컬 빌드가 실패하는 문제를 수정하고, `SampleMapper` DAO의 나머지 CRUD 메서드에 대한 단위 테스트를 추가합니다.

## 변경 내용

**pom.xml**
- `maven-compiler-plugin`에 `annotationProcessorPaths` 추가 — Lombok annotation processor가 올바르게 등록되어 `@Getter`/`@Setter` 생성 코드를 인식
- `skipTests` 설정을 property로 외부화(`<skipTests>${skipTests}</skipTests>`) — CLI에서 `-DskipTests=false`로 테스트 실행 가능

**SampleMapper 단위 테스트 4개 신규 추가**
- `SampleMapperTestSelectSampleTest` — `selectSample` 단건 조회 검증
- `SampleMapperTestUpdateSampleTest` — `updateSample` 수정 후 재조회 검증
- `SampleMapperTestDeleteSampleTest` — `deleteSample` 삭제 후 null 반환 검증
- `SampleMapperTestSelectSampleListTest` — `selectSampleList` / `selectSampleListTotCnt` 목록 조회 및 전체 건수 검증

기존 `SampleMapperTestInsertSampleTest`와 동일한 패턴(given-when-then, `EgovTestAbstractSpring`, HSQLDB 인메모리 DB, `@Transactional` 롤백)을 따릅니다.

## 테스트 확인

```
mvn test -Dtest="SampleMapperTestSelectSampleTest,SampleMapperTestUpdateSampleTest,SampleMapperTestDeleteSampleTest,SampleMapperTestSelectSampleListTest" -DskipTests=false
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
```

## 체크리스트

- [x] 단일 주제만 다룸 (Lombok 빌드 수정 + SampleMapper 테스트)
- [x] 기존 동작에 영향 없음 (annotation processor 추가는 컴파일 정상화, skipTests 기본값 유지)
- [x] 테스트 통과 확인 (4/4 pass)
