### PR TITLE
[test][web-sample] EgovBindingInitializer 단위 테스트 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,12 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<release>${java.version}</release>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</path>
+					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -179,7 +185,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
-					<skipTests>true</skipTests>
+					<skipTests>${skipTests}</skipTests>
 					<reportFormat>xml</reportFormat>
 					<excludes>
 						<exclude>**/Abstract*.java</exclude>

--- a/src/test/java/egovframework/example/cmmn/web/EgovBindingInitializerTest.java
+++ b/src/test/java/egovframework/example/cmmn/web/EgovBindingInitializerTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2008-2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package egovframework.example.cmmn.web;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.beans.PropertyEditor;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.PropertyEditorRegistry;
+import org.springframework.web.bind.WebDataBinder;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * EgovBindingInitializer 단위 테스트
+ *
+ * @author 이백행
+ * @since 2024-09-21
+ */
+@Slf4j
+class EgovBindingInitializerTest {
+
+	private EgovBindingInitializer bindingInitializer;
+
+	private WebDataBinder binder;
+
+	@BeforeEach
+	void setUp() {
+		bindingInitializer = new EgovBindingInitializer();
+		binder = new WebDataBinder(null);
+		bindingInitializer.initBinder(binder);
+	}
+
+	@Test
+	@DisplayName("날짜 문자열 yyyy-MM-dd 형식을 Date로 변환한다")
+	void testDateEditorValidFormat() throws ParseException {
+		// given
+		final String dateStr = "2024-01-15";
+		final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault());
+		final Date expected = sdf.parse(dateStr);
+
+		// when
+		final PropertyEditor editor = binder.findCustomEditor(Date.class, null);
+		assertNotNull(editor);
+		editor.setAsText(dateStr);
+		final Date result = (Date) editor.getValue();
+
+		// then
+		assertEquals(expected, result);
+
+		if (log.isDebugEnabled()) {
+			log.debug("dateStr={}", dateStr);
+			log.debug("result={}", result);
+		}
+	}
+
+	@Test
+	@DisplayName("잘못된 날짜 형식(yyyy/MM/dd)은 변환에 실패한다")
+	void testDateEditorInvalidFormat() {
+		// given
+		final String invalidDateStr = "2024/01/15";
+		final PropertyEditor editor = binder.findCustomEditor(Date.class, null);
+		assertNotNull(editor);
+
+		// when & then
+		assertThrows(Exception.class, () -> editor.setAsText(invalidDateStr));
+
+		if (log.isDebugEnabled()) {
+			log.debug("invalidDateStr={}", invalidDateStr);
+		}
+	}
+
+	@Test
+	@DisplayName("StringTrimmerEditor가 등록되어 문자열 앞뒤 공백을 제거한다")
+	void testStringTrimmerEditor() {
+		// given
+		final String paddedStr = "  hello world  ";
+
+		// when
+		final PropertyEditorRegistry registry = binder;
+		final PropertyEditor editor = registry.findCustomEditor(String.class, null);
+
+		// then
+		assertNotNull(editor);
+
+		editor.setAsText(paddedStr);
+		final String result = (String) editor.getValue();
+		assertEquals("hello world", result);
+
+		if (log.isDebugEnabled()) {
+			log.debug("paddedStr='{}'", paddedStr);
+			log.debug("result='{}'", result);
+		}
+	}
+
+	@Test
+	@DisplayName("Date PropertyEditor가 등록되어 있다")
+	void testDateEditorIsRegistered() {
+		// given & when
+		final PropertyEditorRegistry registry = binder;
+		final PropertyEditor editor = registry.findCustomEditor(Date.class, null);
+
+		// then
+		assertNotNull(editor);
+
+		if (log.isDebugEnabled()) {
+			log.debug("editor={}", editor);
+		}
+	}
+
+}


### PR DESCRIPTION
EgovBindingInitializer의 initBinder 동작을 검증하는 단위 테스트를 추가한다.

**변경 내용**

- `EgovBindingInitializerTest.java` 신규 추가 (테스트 4개)
  - 유효한 `yyyy-MM-dd` 날짜 문자열 → `Date` 변환 검증
  - 잘못된 날짜 형식(`yyyy/MM/dd`) 입력 시 예외 발생 검증
  - `StringTrimmerEditor` 등록 여부 및 공백 제거 동작 검증
  - `CustomDateEditor`가 `PropertyEditorRegistry`에 등록됨을 검증

- `pom.xml` 수정
  - `maven-compiler-plugin`에 `annotationProcessorPaths` 추가 → Lombok `@Slf4j` 등이 테스트 소스에서 정상 동작
  - `maven-surefire-plugin`의 `<skipTests>true</skipTests>` 하드코딩을 `${skipTests}`로 변경 → `-DskipTests=false` 옵션으로 테스트 실행 가능

**테스트 결과**

```
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
```

**체크리스트**

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음
- [x] 테스트 통과 확인
