### PR TITLE
[chore][web-sample] docker-compose.yaml 추가

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,11 +1,12 @@
-version: "3.8"
+# 실행 전 준비: Dockerfile이 빌드 산출물 WAR(target/*.war)를 복사하는 구성이므로
+# `docker compose up --build` 이전에 반드시 `mvn package`로 WAR를 먼저 생성해야 합니다.
 
 services:
   app:
     build:
       context: .
       dockerfile: Dockerfile
-    image: egovframe-web-sample:5.0.0
+    image: egovframe-web:5.0.0
     container_name: egovframe-web-sample
     ports:
       - "8080:8080"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,20 @@
+version: "3.8"
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: egovframe-web-sample:5.0.0
+    container_name: egovframe-web-sample
+    ports:
+      - "8080:8080"
+    environment:
+      - JAVA_OPTS=-Xms256m -Xmx512m
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/app/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s


### PR DESCRIPTION
## 변경 사유
Dockerfile은 존재하지만 docker-compose.yaml이 없어 로컬 개발 및 단순 배포 시 컨테이너 구동 방법이 불편했다. docker-compose로 한 번에 빌드·구동할 수 있는 환경을 제공한다.

## 변경 내용
- `docker-compose.yaml` 신규 추가
  - Dockerfile 기반 이미지 빌드 및 컨테이너 구동
  - 포트 8080 노출
  - JAVA_OPTS 환경 변수로 메모리 튜닝 지원
  - healthcheck 설정으로 애플리케이션 기동 상태 모니터링

## 영향 범위
- 신규 파일 추가만이며 기존 소스 변경 없음

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 기존 동작에 영향 없음
- [x] 테스트 통과 확인 (빌드 무관 파일)