### PR TITLE
[test][main] SampleVO/SampleDefaultVO 순수 단위 테스트 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,12 +160,6 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<release>${java.version}</release>
-					<annotationProcessorPaths>
-						<path>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</path>
-					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -185,7 +179,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
-					<skipTests>false</skipTests>
+					<skipTests>true</skipTests>
 					<reportFormat>xml</reportFormat>
 					<excludes>
 						<exclude>**/Abstract*.java</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,12 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<release>${java.version}</release>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</path>
+					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -179,7 +185,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
-					<skipTests>true</skipTests>
+					<skipTests>false</skipTests>
 					<reportFormat>xml</reportFormat>
 					<excludes>
 						<exclude>**/Abstract*.java</exclude>

--- a/src/test/java/egovframework/example/sample/service/SampleDefaultVOTest.java
+++ b/src/test/java/egovframework/example/sample/service/SampleDefaultVOTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2008-2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package egovframework.example.sample.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * [게시판] SampleDefaultVO 단위 테스트
+ *
+ * @author 이백행
+ * @since 2024-09-21
+ */
+class SampleDefaultVOTest {
+
+    private SampleDefaultVO vo;
+
+    @BeforeEach
+    void setUp() {
+        vo = new SampleDefaultVO();
+    }
+
+    @Test
+    @DisplayName("검색조건 기본값은 빈 문자열이다")
+    void searchConditionDefaultIsEmpty() {
+        assertEquals("", vo.getSearchCondition());
+    }
+
+    @Test
+    @DisplayName("검색 키워드 기본값은 빈 문자열이다")
+    void searchKeywordDefaultIsEmpty() {
+        assertEquals("", vo.getSearchKeyword());
+    }
+
+    @Test
+    @DisplayName("현재 페이지 기본값은 1이다")
+    void pageIndexDefaultIsOne() {
+        assertEquals(1, vo.getPageIndex());
+    }
+
+    @Test
+    @DisplayName("페이지 단위 기본값은 10이다")
+    void pageUnitDefaultIsTen() {
+        assertEquals(10, vo.getPageUnit());
+    }
+
+    @Test
+    @DisplayName("페이지 사이즈 기본값은 10이다")
+    void pageSizeDefaultIsTen() {
+        assertEquals(10, vo.getPageSize());
+    }
+
+    @Test
+    @DisplayName("페이지당 레코드 수 기본값은 10이다")
+    void recordCountPerPageDefaultIsTen() {
+        assertEquals(10, vo.getRecordCountPerPage());
+    }
+
+    @Test
+    @DisplayName("firstIndex 기본값은 1이다")
+    void firstIndexDefaultIsOne() {
+        assertEquals(1, vo.getFirstIndex());
+    }
+
+    @Test
+    @DisplayName("lastIndex 기본값은 1이다")
+    void lastIndexDefaultIsOne() {
+        assertEquals(1, vo.getLastIndex());
+    }
+
+    @Test
+    @DisplayName("검색조건 setter/getter가 정상 동작한다")
+    void searchConditionSetterGetter() {
+        vo.setSearchCondition("1");
+        assertEquals("1", vo.getSearchCondition());
+    }
+
+    @Test
+    @DisplayName("검색 키워드 setter/getter가 정상 동작한다")
+    void searchKeywordSetterGetter() {
+        vo.setSearchKeyword("테스트");
+        assertEquals("테스트", vo.getSearchKeyword());
+    }
+
+    @Test
+    @DisplayName("페이지 인덱스 setter/getter가 정상 동작한다")
+    void pageIndexSetterGetter() {
+        vo.setPageIndex(3);
+        assertEquals(3, vo.getPageIndex());
+    }
+
+    @Test
+    @DisplayName("toString이 null이 아니다")
+    void toStringIsNotNull() {
+        assertNotNull(vo.toString());
+    }
+
+    @Test
+    @DisplayName("toString이 필드명을 포함한다")
+    void toStringContainsFieldNames() {
+        String result = vo.toString();
+        assertNotNull(result);
+        assertEquals(true, result.contains("pageIndex"));
+    }
+
+}

--- a/src/test/java/egovframework/example/sample/service/SampleVOTest.java
+++ b/src/test/java/egovframework/example/sample/service/SampleVOTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2008-2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package egovframework.example.sample.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * [게시판] SampleVO 단위 테스트
+ *
+ * @author 이백행
+ * @since 2024-09-21
+ */
+class SampleVOTest {
+
+    private SampleVO vo;
+
+    @BeforeEach
+    void setUp() {
+        vo = new SampleVO();
+    }
+
+    @Test
+    @DisplayName("id 초기값은 null이다")
+    void idDefaultIsNull() {
+        assertNull(vo.getId());
+    }
+
+    @Test
+    @DisplayName("name 초기값은 null이다")
+    void nameDefaultIsNull() {
+        assertNull(vo.getName());
+    }
+
+    @Test
+    @DisplayName("description 초기값은 null이다")
+    void descriptionDefaultIsNull() {
+        assertNull(vo.getDescription());
+    }
+
+    @Test
+    @DisplayName("useYn 초기값은 null이다")
+    void useYnDefaultIsNull() {
+        assertNull(vo.getUseYn());
+    }
+
+    @Test
+    @DisplayName("regUser 초기값은 null이다")
+    void regUserDefaultIsNull() {
+        assertNull(vo.getRegUser());
+    }
+
+    @Test
+    @DisplayName("id setter/getter가 정상 동작한다")
+    void idSetterGetter() {
+        vo.setId("SAMPLE-001");
+        assertEquals("SAMPLE-001", vo.getId());
+    }
+
+    @Test
+    @DisplayName("name setter/getter가 정상 동작한다")
+    void nameSetterGetter() {
+        vo.setName("테스트 게시글");
+        assertEquals("테스트 게시글", vo.getName());
+    }
+
+    @Test
+    @DisplayName("description setter/getter가 정상 동작한다")
+    void descriptionSetterGetter() {
+        vo.setDescription("설명 내용");
+        assertEquals("설명 내용", vo.getDescription());
+    }
+
+    @Test
+    @DisplayName("useYn setter/getter가 정상 동작한다")
+    void useYnSetterGetter() {
+        vo.setUseYn("Y");
+        assertEquals("Y", vo.getUseYn());
+    }
+
+    @Test
+    @DisplayName("regUser setter/getter가 정상 동작한다")
+    void regUserSetterGetter() {
+        vo.setRegUser("admin");
+        assertEquals("admin", vo.getRegUser());
+    }
+
+    @Test
+    @DisplayName("SampleVO는 SampleDefaultVO를 상속한다")
+    void sampleVOExtendsSampleDefaultVO() {
+        assertInstanceOf(SampleDefaultVO.class, vo);
+    }
+
+    @Test
+    @DisplayName("SampleDefaultVO에서 상속받은 페이지 기본값이 정상이다")
+    void inheritedPageIndexDefaultIsOne() {
+        assertEquals(1, vo.getPageIndex());
+    }
+
+    @Test
+    @DisplayName("toString이 null이 아니다")
+    void toStringIsNotNull() {
+        vo.setId("SAMPLE-001");
+        vo.setName("테스트");
+        assertNotNull(vo.toString());
+    }
+
+    @Test
+    @DisplayName("여러 필드를 동시에 설정하면 각각 정상 반환된다")
+    void multipleFieldsSetAndGet() {
+        vo.setId("S-100");
+        vo.setName("게시글 제목");
+        vo.setDescription("게시글 내용");
+        vo.setUseYn("Y");
+        vo.setRegUser("user01");
+
+        assertEquals("S-100", vo.getId());
+        assertEquals("게시글 제목", vo.getName());
+        assertEquals("게시글 내용", vo.getDescription());
+        assertEquals("Y", vo.getUseYn());
+        assertEquals("user01", vo.getRegUser());
+    }
+
+}


### PR DESCRIPTION
## 변경 사유

기존 테스트 코드가 모두 DB 연동 통합 테스트(Spring 컨텍스트 + H2/MySQL)로만 구성되어 있어,
순수 도메인 로직에 대한 빠르고 독립적인 단위 테스트가 없었습니다.
SampleVO와 SampleDefaultVO는 외부 의존 없는 순수 POJO이므로 단위 테스트 대상으로 적합합니다.

## 변경 내용

- `SampleDefaultVOTest.java`: 검색조건·페이지 관련 기본값, setter/getter, toString 동작 검증 (13개 테스트)
- `SampleVOTest.java`: id/name/description 초기값, 상속 관계, 복합 필드 세팅 검증 (14개 테스트)
- `pom.xml`: Lombok `annotationProcessorPaths` 추가 (기존 테스트 파일의 `@Slf4j` 컴파일 오류 수정), `skipTests` false로 변경

## 테스트 결과

```
Tests run: 27, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음 (테스트 파일 및 빌드 설정만 변경)
- [x] 테스트 통과 확인 (27/27 green)
