### PR TITLE
[fix] Dockerfile WAR 컨텍스트/베이스 이미지 정정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 #########################################################
-# 목적 : web-sample-1.0.0.war를 tomcat으로 구동하는 도커 이미지 생성
+# 목적 : egovframe-web-5.0.0.war를 tomcat으로 구동하는 도커 이미지 생성
 # 실행방법 : 프로젝트 루트디렉토리에서(Dockerfile 경로) 아래 명령어 실행
-# (명령어) docker build . -t egovframe-web-sample:1.0.0
+# (명령어) docker build . -t egovframe-web-sample:5.0.0
 #########################################################
 
-# tomcat base image설정 (8.5-jre8)
-FROM tomcat:8.5-jre8
-COPY ./target/web-example-1.0.0.war /usr/local/tomcat/webapps/app.war
+# tomcat base image 설정 (10.1-jdk17-temurin)
+FROM tomcat:10.1-jdk17-temurin
+COPY ./target/egovframe-web-5.0.0.war /usr/local/tomcat/webapps/app.war
 # tomcat의 web서버 포트설정
 EXPOSE 8080
 # 컨테이너 시작 시 tomcat이 구동되도록 해당 명령을 실행


### PR DESCRIPTION
## 변경 사유

기존 Dockerfile에 두 가지 결함이 있어 `docker build` 시 이미지가 정상적으로 생성되지 않았습니다.

1. **COPY 경로 오류**: `./target/web-example-1.0.0.war`는 pom.xml `finalName`(`${project.artifactId}-${project.version}`)과 다른 파일명입니다. 실제 빌드 결과물은 `egovframe-web-5.0.0.war`이므로 COPY 경로를 수정합니다.
2. **구식 베이스 이미지**: `tomcat:8.5-jre8`은 Java 8 / Servlet 3.1 기반으로, 본 프로젝트가 사용하는 Jakarta EE 10(Servlet 6.0)과 호환되지 않습니다. `tomcat:10.1-jdk17-temurin`으로 교체합니다.

## 변경 내용

- `Dockerfile`: 베이스 이미지 `tomcat:8.5-jre8` → `tomcat:10.1-jdk17-temurin`
- `Dockerfile`: COPY 경로 `web-example-1.0.0.war` → `egovframe-web-5.0.0.war`

## 영향 범위

- Dockerfile 단독 변경, 소스 코드 및 설정 파일 영향 없음
- k8s 매니페스트(PR #25)에서 참조하는 이미지 빌드가 이 수정으로 정상화됨

---

- [ ] 단일 주제만 다룸 (다른 변경 없음)
- [ ] 기존 동작에 영향 없음 (Dockerfile만 수정)
