### PR TITLE
[fix] JDK 21+ 빌드에서 Lombok 애너테이션 프로세서 미동작 수정 (annotationProcessorPaths 등록)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,13 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<release>${java.version}</release>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>${lombok.version}</version>
+						</path>
+					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
## 문제

JDK 23부터 `javac`는 클래스패스에서 발견된 애너테이션 프로세서를 기본으로 실행하지 않습니다(`-proc:full`을 명시하지 않으면 미실행). 현재 `lombok`은 `provided` 스코프 의존성으로만 선언되어 있어, JDK 21+(특히 23/26)로 빌드하면 Lombok이 동작하지 않습니다.

그 결과 `@Getter`/`@Setter`로 생성되어야 할 접근자가 만들어지지 않아 컴파일이 실패합니다.

```
[ERROR] EgovSampleController.java:[87,25] cannot find symbol
  symbol: method setFirstIndex(int)  location: variable sampleVO of type ... SampleVO
[ERROR] ... getSearchCondition(), getSearchKeyword(), getPageIndex() ...
```

- JDK 17(표준프레임워크 5.0 기준 버전)에서는 정상 빌드됩니다.
- JDK 21/23/26 환경에서 재현됩니다(`SampleDefaultVO`/`SampleVO`가 Lombok 사용).

## 변경

`maven-compiler-plugin`에 `annotationProcessorPaths`로 Lombok을 명시적으로 등록합니다.

```xml
<annotationProcessorPaths>
    <path>
        <groupId>org.projectlombok</groupId>
        <artifactId>lombok</artifactId>
        <version>${lombok.version}</version>
    </path>
</annotationProcessorPaths>
```

- 버전은 부모 POM(`egovframe-web-config-parent`)이 관리하는 `${lombok.version}`을 그대로 사용해 버전 드리프트가 없습니다.
- `release` 타깃은 `${java.version}`(17) 그대로이며 JDK 17 빌드 동작에 영향이 없습니다.

## 검증

- 변경 전(JDK 26): `cannot find symbol` 컴파일 실패 재현.
- 변경 후(JDK 26): `mvn clean test` → BUILD SUCCESS.
- JDK 17 빌드는 영향 없음(애너테이션 프로세서를 명시 등록할 뿐, release 타깃 동일).

## 체크리스트
- [x] 단일 주제(빌드 구성)만 변경, pom.xml 1개 파일
- [x] base = main
- [x] 기존 JDK 17 빌드 영향 없음